### PR TITLE
DKMS: Build against the correct kernel version

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,7 @@
 PACKAGE_NAME="rtl8812AU"
 PACKAGE_VERSION="#MODULE_VERSION#"
 BUILT_MODULE_NAME[0]="8812au"
-MAKE="'make'"
+MAKE="'make' KVER=${kernelver}"
 CLEAN="'make' clean"
 DEST_MODULE_LOCATION[0]="/updates/dkms"
 AUTOINSTALL="YES"


### PR DESCRIPTION
Fix DKMS configuration so that the drivers are compiled against the kernel
version about to be installed instead of the currently running version.

This way the driver is correctly loaded after a kernel update and reboot.

This is a common bug found in several other versions from this driver laying around in the internet:

- https://askubuntu.com/questions/799108/2-dkms-drivers-wont-build-correctly-when-installing-new-kernel-after-software-u
- https://askubuntu.com/questions/979296/usb-wifi-adapter-stopped-working-after-forceful-shutdown
- https://github.com/gnab/rtl8812au/commit/37da69e6723514ba49fadff57fc1081ba57e87a6